### PR TITLE
Fixes default version numbers

### DIFF
--- a/cli/lib/cli/ide/appcode_user_pref_dir.rb
+++ b/cli/lib/cli/ide/appcode_user_pref_dir.rb
@@ -8,7 +8,7 @@ module Cli
       end
 
       def default_ide_pref_dir_version
-        '33'
+        '2018.3'
       end
     end
   end

--- a/cli/lib/cli/ide/pycharm_user_pref_dir.rb
+++ b/cli/lib/cli/ide/pycharm_user_pref_dir.rb
@@ -8,7 +8,7 @@ module Cli
       end
 
       def default_ide_pref_dir_version
-        "4"
+        "2018.3"
       end
     end
   end


### PR DESCRIPTION
- I was trying to install Pycharm and came across this issue
  Jetbrains switched from numbered versions to year-based versions